### PR TITLE
Fix: pdf read as unkown file using safari on windows

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -17,7 +17,11 @@ class HomeController < ApplicationController
     @warnings = @comprobante.notifications.warnings
     @errors = @comprobante.notifications.errors
     pdf = render_to_string :pdf => "PDF_SoyReceptor", :template => "home/download_pdf.html.erb", :encoding => "UTF-8", :layout=>'pdf'
-    send_data pdf
+    save_path = Rails.root.join('public',"#{@comprobante.id.to_s}.pdf")
+    File.open(save_path, 'wb') do |file|
+      file << pdf
+    end
+    send_file save_path
   end
  
   def index


### PR DESCRIPTION
@andresamayadiaz - I found this when testing on Safari on Windows. PDF is saved as unknown file and need to be renamed so it can be opened